### PR TITLE
tweaks

### DIFF
--- a/igv4/VulcanSoAConnecthathon37/input/fsh/activitydefinitions/example-activity-definition-h2q-mc-lzzt-vitalsigns.fsh
+++ b/igv4/VulcanSoAConnecthathon37/input/fsh/activitydefinitions/example-activity-definition-h2q-mc-lzzt-vitalsigns.fsh
@@ -22,7 +22,7 @@ Usage: #inline
 Title: "Vital Signs/Temperature"
 * status = #active
 * title = "Vital Signs - Temperature"
-* name = "Vital Signs - Temperature"
+* name = "VitalSigns_Temperature"
 * intent = #order
 * kind = #ServiceRequest
 * identifier[+]

--- a/igv4/VulcanSoAConnecthathon37/input/fsh/activitydefinitions/example_activity-definition-visit-date.fsh
+++ b/igv4/VulcanSoAConnecthathon37/input/fsh/activitydefinitions/example_activity-definition-visit-date.fsh
@@ -1,7 +1,7 @@
 Instance: SoA-PoC-Visit-Date
 InstanceOf: ActivityDefinition
 Usage: #inline
-* name = "Record Visit Date"
+* name = "RecordVisitDate"
 * title = "Record Visit Date"
 * description = "Note the Date of the Encounter in the Patient Recorc"
 * status =  #active

--- a/igv4/VulcanSoAConnecthathon37/input/fsh/activitydefinitions/example_activity-defintion-schedule-encounter.fsh
+++ b/igv4/VulcanSoAConnecthathon37/input/fsh/activitydefinitions/example_activity-defintion-schedule-encounter.fsh
@@ -1,7 +1,7 @@
 Instance: InitiateVisitProcess
 InstanceOf: ActivityDefinition
 Usage: #inline
-* name = "Schedule Encounter"
+* name = "ScheduleEncounter"
 * title = "Schedule Encounter"
 * description = "Initiate the process for an Encounter to be scheduled between a Patient participating as a ResearchSubject and a Healthcare Provider participating as a Investigator."
 * status =  #active

--- a/igv4/VulcanSoAConnecthathon37/input/fsh/poc/example-researchstudy-poc.fsh
+++ b/igv4/VulcanSoAConnecthathon37/input/fsh/poc/example-researchstudy-poc.fsh
@@ -6,5 +6,4 @@ Usage: #example
   * value = "vulcan_soa_poc_01"
 * title = "Vulcan Schedule of Activities PoC - ResearchStudy"
 * protocol = Reference(PlanDefinition/SoA-PoC-ProtocolDesign)
-//* phase = #phase-2
-* phase.text = "phase-2"
+* phase = $research-study-phase#phase-2 "Phase 2"

--- a/igv4/VulcanSoAConnecthathon37/input/fsh/poc/example-researchstudy-poc.fsh
+++ b/igv4/VulcanSoAConnecthathon37/input/fsh/poc/example-researchstudy-poc.fsh
@@ -6,4 +6,5 @@ Usage: #example
   * value = "vulcan_soa_poc_01"
 * title = "Vulcan Schedule of Activities PoC - ResearchStudy"
 * protocol = Reference(PlanDefinition/SoA-PoC-ProtocolDesign)
-* phase = #phase-2
+//* phase = #phase-2
+* phase.text = "phase-2"

--- a/igv4/VulcanSoAConnecthathon37/input/fsh/poc/performing/01-screening/example-demographics.fsh
+++ b/igv4/VulcanSoAConnecthathon37/input/fsh/poc/performing/01-screening/example-demographics.fsh
@@ -8,7 +8,8 @@ Usage: #example
 * meta.lastUpdated = "2024-06-12T11:49:48.000-04:00"
 * meta.source = "#vAcRbS6QlY9zun9y"
 * meta.profile = "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaireresponse|3.0"
-* meta.tag.code = #"lformsVersion: 36.1.3"
+//* meta.tag.code = #"lformsVersion: 36.1.3"
+* meta.tag.display = "lformsVersion: 36.1.3"
 * questionnaire = "Questionnaire/Demographics-Questionnaire"
 * status = #completed
 * subject = Reference(Patient/5770842) "Abbey, Robynn"

--- a/igv4/VulcanSoAConnecthathon37/input/fsh/poc/performing/01-screening/example-height-weight-screening.fsh
+++ b/igv4/VulcanSoAConnecthathon37/input/fsh/poc/performing/01-screening/example-height-weight-screening.fsh
@@ -7,7 +7,8 @@ Usage: #example
 * meta.lastUpdated = "2024-06-12T11:16:46.000-04:00"
 * meta.source = "#WOtdXcTXAd1IxS7q"
 * meta.profile = "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaireresponse|3.0"
-* meta.tag.code = #"lformsVersion: 36.1.3"
+//* meta.tag.code = #"lformsVersion: 36.1.3"
+* meta.tag.display = "lformsVersion: 36.1.3"
 * questionnaire = "Questionnaire/Vulcan-SoA-Height-Weight-Panel"
 * status = #completed
 * subject = Reference(Patient/5770842) "Abbey, Robynn"

--- a/igv4/VulcanSoAConnecthathon37/input/fsh/poc/performing/02-baseline/example-questionnaire-response-phq-15-baseline.fsh
+++ b/igv4/VulcanSoAConnecthathon37/input/fsh/poc/performing/02-baseline/example-questionnaire-response-phq-15-baseline.fsh
@@ -6,7 +6,8 @@ Usage: #example
 * meta.lastUpdated = "2024-05-29T11:33:28.000-04:00"
 * meta.source = "#0lIZjVUX1cOEzu37"
 * meta.profile = "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaireresponse|3.0"
-* meta.tag.code = #"lformsVersion: 36.0.5"
+//* meta.tag.code = #"lformsVersion: 36.0.5"
+* meta.tag.display = "lformsVersion: 36.0.5"
 * questionnaire = "Questionnaire/PHQ-15-Questionnaire"
 * status = #completed
 * subject = Reference(Patient/Bill-Hicks) "Hicks, Bill"

--- a/igv4/VulcanSoAConnecthathon37/input/fsh/poc/planning/planning-bundle.fsh
+++ b/igv4/VulcanSoAConnecthathon37/input/fsh/poc/planning/planning-bundle.fsh
@@ -29,6 +29,7 @@ Usage: #example
     * url = "ActivityDefinition"
 * entry[+]
   * resource = SoA-PoC-ProtocolDesign
+  * fullUrl = "https://soa.vulcan.org/PlanDefinition/SoA-PoC-ProtocolDesign"
   * request
     * method = #POST  
     * url = "PlanDefinition"

--- a/igv4/VulcanSoAConnecthathon37/input/fsh/questionnaires/example-bp-panel.fsh
+++ b/igv4/VulcanSoAConnecthathon37/input/fsh/questionnaires/example-bp-panel.fsh
@@ -3,8 +3,8 @@ InstanceOf: Questionnaire
 Usage: #inline
 * meta
   * profile = "http://hl7.org/fhir/4.0/StructureDefinition/Questionnaire"
-  * tag
-    * code = #"lformsVersion: 36.0.5"
+  * tag.display = "lformsVersion: 36.0.5"
+//    * code = #"lformsVersion: 36.0.5"
 * title = "Blood pressure panel mean systolic and mean diastolic"
 * status = #draft
 * code = $loinc#96607-7 "Blood pressure panel mean systolic and mean diastolic"

--- a/igv4/VulcanSoAConnecthathon37/input/fsh/questionnaires/example-demographics-lhc.fsh
+++ b/igv4/VulcanSoAConnecthathon37/input/fsh/questionnaires/example-demographics-lhc.fsh
@@ -2,7 +2,8 @@ Instance: Demographics-Questionnaire
 InstanceOf: Questionnaire
 Usage: #inline
 * meta.profile = "http://hl7.org/fhir/4.0/StructureDefinition/Questionnaire"
-* meta.tag.code = #"lformsVersion: 36.1.3"
+//* meta.tag.code = #"lformsVersion: 36.1.3"
+* meta.tag.display = "lformsVersion: 36.1.3"
 * title = "Patient demographics panel"
 * status = #draft
 * code = $loinc#79191-3 "Patient demographics panel"

--- a/igv4/VulcanSoAConnecthathon37/input/fsh/questionnaires/example-height-weight.fsh
+++ b/igv4/VulcanSoAConnecthathon37/input/fsh/questionnaires/example-height-weight.fsh
@@ -2,7 +2,8 @@ Instance: Vulcan-SoA-Height-Weight-Panel
 InstanceOf: Questionnaire
 Usage: #inline
 * meta.profile = "http://hl7.org/fhir/4.0/StructureDefinition/Questionnaire"
-* meta.tag.code = #"lformsVersion: 36.1.3"
+//* meta.tag.code = #"lformsVersion: 36.1.3"
+* meta.tag.display = "lformsVersion: 36.1.3"
 * title = "Weight and Height tracking panel"
 * status = #draft
 * code = $loinc#55418-8 "Weight and Height tracking panel"

--- a/igv4/VulcanSoAConnecthathon37/input/fsh/questionnaires/example-qs-phq-15.fsh
+++ b/igv4/VulcanSoAConnecthathon37/input/fsh/questionnaires/example-qs-phq-15.fsh
@@ -2,7 +2,8 @@ Instance: PHQ-15-Questionnaire
 InstanceOf: Questionnaire
 Usage: #inline
 * meta.profile = "http://hl7.org/fhir/4.0/StructureDefinition/Questionnaire"
-* meta.tag.code = #"lformsVersion: 36.0.4"
+//* meta.tag.code = #"lformsVersion: 36.0.4"
+* meta.tag.display = "lformsVersion: 36.0.4"
 * title = "Patient Health Questionnaire 15 item (PHQ-15) [Reported]"
 * status = #draft
 * copyright = "Copyright © Pfizer Inc. All rights reserved. Developed by Drs. Robert L. Spitzer, Janet B.W. Williams, Kurt Kroenke and colleagues, with an educational grant from Pfizer Inc. No permission required to reproduce, translate, display or distribute."


### PR DESCRIPTION
Summary of warnings etc addressed and the changes

Warning
Line: 1854, Col:8
Constraint failed: cnl-0: 'Name should be usable as an identifier for the module by machine processing applications such as code generation' (defined in http://hl7.org/fhir/StructureDefinition/ActivityDefinition)

changed name field
-------------------------------
EXAMPLE OF several of the following
Warning
Line: 592, Col:14
A code with no system has no defined meaning, and it cannot be validated. A system should be provided

          "tag": [
            {
              "code": "lformsVersion: 36.0.4"
            }

changed from code to display for lformsVersion: X
-------------------------------
Warning
Line: 2433, Col:10
Coding has no system. A code with no system has no defined meaning, and it cannot be validated. A system should be provided
      "resource": {
        "resourceType": "ResearchStudy",
        "id": "SoA-PoC-ResearchStudy",
        "identifier": [
          {
            "value": "vulcan_soa_poc_01"
          }
        ],
        "protocol": [
          {
            "reference": "PlanDefinition/SoA-PoC-ProtocolDesign"
          }
        ],
        "status": "active",
        "title": "Vulcan Schedule of Activities PoC - ResearchStudy",
        "phase": {
          "coding": [
            {
              "code": "phase-2"
            }
          ]
        }
      }
changed to phase.text
-------------------------------------
Warning
Line: -1, Col:-1
Entry 5 matches the reference PlanDefinition/SoA-PoC-ProtocolDesign by type and id but it does not match the full target URL https://soa.vulcan.org/PlanDefinition/SoA-PoC-ProtocolDesign by Bundle resolution rules

added fullUrl

* entry[+]
  * resource = SoA-PoC-ProtocolDesign
  * fullUrl = "https://soa.vulcan.org/PlanDefinition/SoA-PoC-ProtocolDesign" added fullUrl